### PR TITLE
Add KoreanTranslationCamera iOS MVP app

### DIFF
--- a/KoreanTranslationCamera/KoreanTranslationCamera.xcodeproj/project.pbxproj
+++ b/KoreanTranslationCamera/KoreanTranslationCamera.xcodeproj/project.pbxproj
@@ -1,0 +1,401 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		FA100001000000000000001B /* KoreanTranslationCameraApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100001000000000000001A /* KoreanTranslationCameraApp.swift */; };
+		FA100002000000000000001B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100002000000000000001A /* ContentView.swift */; };
+		FA100003000000000000001B /* AppModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100003000000000000001A /* AppModels.swift */; };
+		FA100004000000000000001B /* CameraManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100004000000000000001A /* CameraManager.swift */; };
+		FA100005000000000000001B /* CameraPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100005000000000000001A /* CameraPreviewView.swift */; };
+		FA100006000000000000001B /* OCRService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100006000000000000001A /* OCRService.swift */; };
+		FA100007000000000000001B /* TranslationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100007000000000000001A /* TranslationService.swift */; };
+		FA100008000000000000001B /* LanguageSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100008000000000000001A /* LanguageSelectorView.swift */; };
+		FA100009000000000000001B /* TranslationResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100009000000000000001A /* TranslationResultView.swift */; };
+		FA10000A000000000000001B /* ControlBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA10000A000000000000001A /* ControlBarView.swift */; };
+		FA10000B000000000000001B /* PermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA10000B000000000000001A /* PermissionView.swift */; };
+		FA10000C000000000000001B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FA10000C000000000000001A /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		FA100000000000000000001A /* KoreanTranslationCamera.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KoreanTranslationCamera.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA100001000000000000001A /* KoreanTranslationCameraApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanTranslationCameraApp.swift; sourceTree = "<group>"; };
+		FA100002000000000000001A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		FA100003000000000000001A /* AppModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppModels.swift; sourceTree = "<group>"; };
+		FA100004000000000000001A /* CameraManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraManager.swift; sourceTree = "<group>"; };
+		FA100005000000000000001A /* CameraPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewView.swift; sourceTree = "<group>"; };
+		FA100006000000000000001A /* OCRService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRService.swift; sourceTree = "<group>"; };
+		FA100007000000000000001A /* TranslationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationService.swift; sourceTree = "<group>"; };
+		FA100008000000000000001A /* LanguageSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSelectorView.swift; sourceTree = "<group>"; };
+		FA100009000000000000001A /* TranslationResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationResultView.swift; sourceTree = "<group>"; };
+		FA10000A000000000000001A /* ControlBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlBarView.swift; sourceTree = "<group>"; };
+		FA10000B000000000000001A /* PermissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionView.swift; sourceTree = "<group>"; };
+		FA10000C000000000000001A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		FA10000D000000000000001A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		FB000003000000000000001A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		FB000000000000000000001A /* MainGroup */ = {
+			isa = PBXGroup;
+			children = (
+				FB000010000000000000001A /* KoreanTranslationCamera */,
+				FB000020000000000000001A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		FB000010000000000000001A /* KoreanTranslationCamera */ = {
+			isa = PBXGroup;
+			children = (
+				FA100001000000000000001A /* KoreanTranslationCameraApp.swift */,
+				FA100002000000000000001A /* ContentView.swift */,
+				FB000011000000000000001A /* Models */,
+				FB000012000000000000001A /* Camera */,
+				FB000013000000000000001A /* Services */,
+				FB000014000000000000001A /* Views */,
+				FA10000C000000000000001A /* Assets.xcassets */,
+				FA10000D000000000000001A /* Info.plist */,
+			);
+			path = KoreanTranslationCamera;
+			sourceTree = "<group>";
+		};
+		FB000011000000000000001A /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				FA100003000000000000001A /* AppModels.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		FB000012000000000000001A /* Camera */ = {
+			isa = PBXGroup;
+			children = (
+				FA100004000000000000001A /* CameraManager.swift */,
+				FA100005000000000000001A /* CameraPreviewView.swift */,
+			);
+			path = Camera;
+			sourceTree = "<group>";
+		};
+		FB000013000000000000001A /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				FA100006000000000000001A /* OCRService.swift */,
+				FA100007000000000000001A /* TranslationService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		FB000014000000000000001A /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				FA100008000000000000001A /* LanguageSelectorView.swift */,
+				FA100009000000000000001A /* TranslationResultView.swift */,
+				FA10000A000000000000001A /* ControlBarView.swift */,
+				FA10000B000000000000001A /* PermissionView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		FB000020000000000000001A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				FA100000000000000000001A /* KoreanTranslationCamera.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		FB000001000000000000001A /* KoreanTranslationCamera */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FC000002000000000000001A /* Build configuration list for PBXNativeTarget "KoreanTranslationCamera" */;
+			buildPhases = (
+				FB000002000000000000001A /* Sources */,
+				FB000003000000000000001A /* Frameworks */,
+				FB000004000000000000001A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = KoreanTranslationCamera;
+			productName = KoreanTranslationCamera;
+			productReference = FA100000000000000000001A /* KoreanTranslationCamera.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		FB000000000000000000002A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
+				LastUpgradeCheck = 1540;
+				TargetAttributes = {
+					FB000001000000000000001A = {
+						CreatedOnToolsVersion = 15.4;
+					};
+				};
+			};
+			buildConfigurationList = FC000001000000000000001A /* Build configuration list for PBXProject "KoreanTranslationCamera" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = FB000000000000000000001A;
+			productRefGroup = FB000020000000000000001A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				FB000001000000000000001A /* KoreanTranslationCamera */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		FB000004000000000000001A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA10000C000000000000001B /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		FB000002000000000000001A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA100001000000000000001B /* KoreanTranslationCameraApp.swift in Sources */,
+				FA100002000000000000001B /* ContentView.swift in Sources */,
+				FA100003000000000000001B /* AppModels.swift in Sources */,
+				FA100004000000000000001B /* CameraManager.swift in Sources */,
+				FA100005000000000000001B /* CameraPreviewView.swift in Sources */,
+				FA100006000000000000001B /* OCRService.swift in Sources */,
+				FA100007000000000000001B /* TranslationService.swift in Sources */,
+				FA100008000000000000001B /* LanguageSelectorView.swift in Sources */,
+				FA100009000000000000001B /* TranslationResultView.swift in Sources */,
+				FA10000A000000000000001B /* ControlBarView.swift in Sources */,
+				FA10000B000000000000001B /* PermissionView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		FC000003000000000000001A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_CYCLE = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		FC000004000000000000001A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_CYCLE = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		FC000005000000000000001A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = KoreanTranslationCamera/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.personal.KoreanTranslationCamera;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = iphoneos;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		FC000006000000000000001A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = KoreanTranslationCamera/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.personal.KoreanTranslationCamera;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = iphoneos;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		FC000001000000000000001A /* Build configuration list for PBXProject "KoreanTranslationCamera" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FC000003000000000000001A /* Debug */,
+				FC000004000000000000001A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FC000002000000000000001A /* Build configuration list for PBXNativeTarget "KoreanTranslationCamera" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FC000005000000000000001A /* Debug */,
+				FC000006000000000000001A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+	};
+	rootObject = FB000000000000000000002A /* Project object */;
+}

--- a/KoreanTranslationCamera/KoreanTranslationCamera/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/KoreanTranslationCamera/KoreanTranslationCamera/Assets.xcassets/Contents.json
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/KoreanTranslationCamera/KoreanTranslationCamera/Camera/CameraManager.swift
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/Camera/CameraManager.swift
@@ -1,0 +1,115 @@
+import AVFoundation
+import UIKit
+
+// MARK: - Camera Manager
+//
+// Manages the AVCaptureSession lifecycle, permission requests, and
+// throttled frame delivery. onFrame is called at most once per frameInterval.
+
+class CameraManager: NSObject, ObservableObject {
+
+    @Published var permissionGranted = false
+    @Published var isRunning = false
+
+    let captureSession = AVCaptureSession()
+
+    /// Called on the camera frame queue with the latest pixel buffer.
+    /// Throttled to frameInterval (default 0.75s) to avoid over-processing.
+    var onFrame: ((CVPixelBuffer) -> Void)?
+
+    private let sessionQueue = DispatchQueue(label: "camera.session.queue", qos: .userInitiated)
+    private let frameQueue  = DispatchQueue(label: "camera.frame.queue",   qos: .userInteractive)
+
+    private var lastFrameTime: Date = .distantPast
+    private let frameInterval: TimeInterval = 0.75
+
+    // MARK: - Permission & Setup
+
+    func requestPermission() {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            DispatchQueue.main.async { self.permissionGranted = true }
+            setupCapture()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                DispatchQueue.main.async { self.permissionGranted = granted }
+                if granted { self.setupCapture() }
+            }
+        default:
+            DispatchQueue.main.async { self.permissionGranted = false }
+        }
+    }
+
+    private func setupCapture() {
+        sessionQueue.async { [weak self] in
+            guard let self else { return }
+
+            self.captureSession.beginConfiguration()
+            self.captureSession.sessionPreset = .hd1280x720
+
+            guard
+                let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back),
+                let input  = try? AVCaptureDeviceInput(device: device),
+                self.captureSession.canAddInput(input)
+            else {
+                self.captureSession.commitConfiguration()
+                return
+            }
+
+            self.captureSession.addInput(input)
+
+            let output = AVCaptureVideoDataOutput()
+            output.videoSettings = [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
+            ]
+            output.setSampleBufferDelegate(self, queue: self.frameQueue)
+            output.alwaysDiscardsLateVideoFrames = true
+
+            if self.captureSession.canAddOutput(output) {
+                self.captureSession.addOutput(output)
+            }
+
+            self.captureSession.commitConfiguration()
+        }
+    }
+
+    // MARK: - Playback Control
+
+    func start() {
+        sessionQueue.async { [weak self] in
+            guard let self, !self.captureSession.isRunning else { return }
+            self.captureSession.startRunning()
+            DispatchQueue.main.async { self.isRunning = true }
+        }
+    }
+
+    func stop() {
+        sessionQueue.async { [weak self] in
+            guard let self, self.captureSession.isRunning else { return }
+            self.captureSession.stopRunning()
+            DispatchQueue.main.async { self.isRunning = false }
+        }
+    }
+
+    func toggleRunning() {
+        isRunning ? stop() : start()
+    }
+}
+
+// MARK: - AVCaptureVideoDataOutputSampleBufferDelegate
+
+extension CameraManager: AVCaptureVideoDataOutputSampleBufferDelegate {
+
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        let now = Date()
+        guard now.timeIntervalSince(lastFrameTime) >= frameInterval else { return }
+        lastFrameTime = now
+
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+        onFrame?(pixelBuffer)
+    }
+}

--- a/KoreanTranslationCamera/KoreanTranslationCamera/Camera/CameraPreviewView.swift
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/Camera/CameraPreviewView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import AVFoundation
+
+// MARK: - Camera Preview (UIViewRepresentable)
+//
+// Wraps an AVCaptureVideoPreviewLayer inside a UIView so it can be
+// embedded in a SwiftUI layout. Uses resizeAspectFill to fill the screen.
+
+struct CameraPreviewView: UIViewRepresentable {
+
+    let session: AVCaptureSession
+
+    func makeUIView(context: Context) -> VideoPreviewUIView {
+        let view = VideoPreviewUIView()
+        view.previewLayer.session      = session
+        view.previewLayer.videoGravity = .resizeAspectFill
+        return view
+    }
+
+    func updateUIView(_ uiView: VideoPreviewUIView, context: Context) {}
+}
+
+// MARK: - VideoPreviewUIView
+
+final class VideoPreviewUIView: UIView {
+
+    override class var layerClass: AnyClass {
+        AVCaptureVideoPreviewLayer.self
+    }
+
+    var previewLayer: AVCaptureVideoPreviewLayer {
+        // swiftlint:disable:next force_cast
+        layer as! AVCaptureVideoPreviewLayer
+    }
+}

--- a/KoreanTranslationCamera/KoreanTranslationCamera/ContentView.swift
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/ContentView.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+import Translation
+
+// MARK: - Content View
+//
+// Root view. Composes the camera preview, language selector, translation result
+// panel, and pause/resume control. Wires up CameraManager → OCRService →
+// TranslationService using closures so each layer stays independent.
+
+struct ContentView: View {
+
+    @StateObject private var cameraManager     = CameraManager()
+    @StateObject private var translationService = TranslationService()
+
+    // OCRService is stateless; no need for @StateObject.
+    private let ocrService = OCRService()
+
+    var body: some View {
+        ZStack {
+            cameraBackground
+            overlayContent
+        }
+        .ignoresSafeArea()
+        .onAppear(perform: setupCamera)
+        .onDisappear { cameraManager.stop() }
+        // Start the session as soon as permission is obtained.
+        .onChange(of: cameraManager.permissionGranted) { _, granted in
+            if granted { cameraManager.start() }
+        }
+        // .translationTask fires once on appear and again whenever
+        // translationService.configuration changes (i.e. language switch).
+        .translationTask(translationService.configuration) { session in
+            await translationService.setSession(session)
+        }
+    }
+
+    // MARK: - Camera Background
+
+    @ViewBuilder
+    private var cameraBackground: some View {
+        if cameraManager.permissionGranted {
+            CameraPreviewView(session: cameraManager.captureSession)
+                .ignoresSafeArea()
+        } else {
+            Color.black.ignoresSafeArea()
+        }
+    }
+
+    // MARK: - Overlay
+
+    private var overlayContent: some View {
+        VStack(spacing: 0) {
+            if !cameraManager.permissionGranted {
+                // Full-screen permission prompt (camera bg is black anyway).
+                PermissionView()
+            } else {
+                // Top: language selector
+                LanguageSelectorView(
+                    selectedLanguage: translationService.targetLanguage,
+                    onSelect: { translationService.changeLanguage(to: $0) }
+                )
+                .padding(.top, 54)
+                .padding(.horizontal, 16)
+
+                Spacer()
+
+                // Paused badge
+                if !cameraManager.isRunning {
+                    Text("Paused")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.white)
+                        .padding(.vertical, 5)
+                        .padding(.horizontal, 14)
+                        .background(.ultraThinMaterial, in: Capsule())
+                        .padding(.bottom, 10)
+                        .transition(.opacity)
+                }
+
+                // Bottom: translation result card
+                TranslationResultView(
+                    result:        translationService.result,
+                    isTranslating: translationService.isTranslating
+                )
+                .padding(.horizontal, 16)
+
+                // Pause / Resume button
+                ControlBarView(isRunning: cameraManager.isRunning) {
+                    cameraManager.toggleRunning()
+                }
+                .padding(.top, 12)
+                .padding(.bottom, 44)
+            }
+        }
+    }
+
+    // MARK: - Setup
+
+    private func setupCamera() {
+        // Capture the TranslationService object directly to avoid capturing
+        // the struct (which is recreated on each render).
+        let ts = translationService
+
+        cameraManager.onFrame = { pixelBuffer in
+            // Called on the camera frame queue; OCR happens here too.
+            ocrService.recognizeKoreanText(in: pixelBuffer) { texts in
+                guard !texts.isEmpty else { return }
+                DispatchQueue.main.async {
+                    ts.translate(texts: texts)
+                }
+            }
+        }
+
+        cameraManager.requestPermission()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/KoreanTranslationCamera/KoreanTranslationCamera/Info.plist
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSCameraUsageDescription</key>
+	<string>The app uses the camera to detect and translate Korean text in real time.</string>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UIRequiresFullScreen</key>
+	<true/>
+</dict>
+</plist>

--- a/KoreanTranslationCamera/KoreanTranslationCamera/KoreanTranslationCameraApp.swift
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/KoreanTranslationCameraApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct KoreanTranslationCameraApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/KoreanTranslationCamera/KoreanTranslationCamera/Models/AppModels.swift
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/Models/AppModels.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+// MARK: - Supported Target Languages
+
+enum SupportedLanguage: String, CaseIterable, Identifiable {
+    case english = "en"
+    case japanese = "ja"
+    case chinese = "zh-Hans"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .english: return "English"
+        case .japanese: return "日本語"
+        case .chinese: return "中文"
+        }
+    }
+
+    var shortName: String {
+        switch self {
+        case .english: return "EN"
+        case .japanese: return "JA"
+        case .chinese: return "ZH"
+        }
+    }
+}
+
+// MARK: - Translation Result
+
+struct TranslationResult: Equatable {
+    let originalText: String
+    let translatedText: String
+    let targetLanguage: SupportedLanguage
+    let timestamp: Date
+
+    static func == (lhs: TranslationResult, rhs: TranslationResult) -> Bool {
+        lhs.originalText == rhs.originalText &&
+        lhs.targetLanguage == rhs.targetLanguage
+    }
+}

--- a/KoreanTranslationCamera/KoreanTranslationCamera/Services/OCRService.swift
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/Services/OCRService.swift
@@ -1,0 +1,53 @@
+import Vision
+import CoreVideo
+
+// MARK: - OCR Service
+//
+// Uses Apple's Vision framework (VNRecognizeTextRequest) to detect Korean text
+// from a CVPixelBuffer. Only results that contain at least one Hangul character
+// are forwarded to the caller; everything else is discarded.
+//
+// The completion handler is always called on the caller's thread (the camera
+// frame queue). Callers are responsible for dispatching to the main queue when
+// updating UI.
+
+final class OCRService {
+
+    // MARK: - Public Interface
+
+    func recognizeKoreanText(
+        in pixelBuffer: CVPixelBuffer,
+        completion: @escaping ([String]) -> Void
+    ) {
+        let request = VNRecognizeTextRequest { request, _ in
+            let candidates = (request.results as? [VNRecognizedTextObservation] ?? [])
+                .compactMap { $0.topCandidates(1).first?.string }
+                .filter { Self.containsKorean($0) }
+
+            completion(candidates)
+        }
+
+        // Korean requires .accurate for reasonable recognition quality.
+        request.recognitionLanguages = ["ko-KR", "ko"]
+        request.recognitionLevel     = .accurate
+        request.usesLanguageCorrection = true
+
+        // Portrait orientation: back camera captures in landscape-right.
+        let handler = VNImageRequestHandler(
+            cvPixelBuffer: pixelBuffer,
+            orientation: .right,
+            options: [:]
+        )
+        try? handler.perform([request])
+    }
+
+    // MARK: - Helpers
+
+    private static func containsKorean(_ text: String) -> Bool {
+        text.unicodeScalars.contains {
+            (0xAC00...0xD7A3).contains($0.value) ||  // Hangul syllables
+            (0x1100...0x11FF).contains($0.value) ||  // Hangul Jamo
+            (0x3130...0x318F).contains($0.value)     // Hangul Compatibility Jamo
+        }
+    }
+}

--- a/KoreanTranslationCamera/KoreanTranslationCamera/Services/TranslationService.swift
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/Services/TranslationService.swift
@@ -1,0 +1,108 @@
+import Translation
+import SwiftUI
+
+// MARK: - Translation Service
+//
+// Wraps Apple's Translation framework (iOS 17.4+).
+//
+// The TranslationSession is provided by the .translationTask() SwiftUI modifier
+// in ContentView; call setSession(_:) from that closure. The session is reused
+// until the target language changes, at which point the configuration refreshes
+// and a new session is supplied automatically.
+//
+// Caches translations by source text to avoid redundant API calls for repeated
+// frames showing the same content.
+
+@MainActor
+final class TranslationService: ObservableObject {
+
+    @Published var result: TranslationResult?
+    @Published var isTranslating = false
+    @Published private(set) var targetLanguage: SupportedLanguage = .english
+
+    // Computed configuration consumed by .translationTask() in the view.
+    var configuration: TranslationSession.Configuration {
+        TranslationSession.Configuration(
+            source: Locale.Language(identifier: "ko"),
+            target: Locale.Language(identifier: targetLanguage.rawValue)
+        )
+    }
+
+    // MARK: - Private State
+
+    private var session: TranslationSession?
+    private var pendingTask: Task<Void, Never>?
+    private var cache: [String: String] = [:]
+    private var lastInputKey: String = ""
+
+    // MARK: - Session Management
+
+    func setSession(_ session: TranslationSession) async {
+        self.session = session
+        // Pre-download language model in the background so first translation
+        // is instant rather than delayed by a model download.
+        try? await session.prepareTranslation()
+    }
+
+    // MARK: - Translation
+
+    func translate(texts: [String]) {
+        let cacheKey = texts.joined(separator: "\n")
+        guard !cacheKey.isEmpty, cacheKey != lastInputKey else { return }
+        lastInputKey = cacheKey
+
+        // Return cached result immediately without hitting the session.
+        if let cached = cache[cacheKey] {
+            result = TranslationResult(
+                originalText: cacheKey,
+                translatedText: cached,
+                targetLanguage: targetLanguage,
+                timestamp: Date()
+            )
+            return
+        }
+
+        // Cancel any in-flight request for stale frames.
+        pendingTask?.cancel()
+
+        pendingTask = Task { [weak self] in
+            guard let self, let session = self.session else { return }
+            self.isTranslating = true
+
+            do {
+                let requests  = texts.map { TranslationSession.Request(sourceString: $0) }
+                let responses = try await session.translations(from: requests)
+
+                guard !Task.isCancelled else { return }
+
+                let translated = responses.map(\.targetText).joined(separator: "\n")
+                self.cache[cacheKey] = translated
+                self.result = TranslationResult(
+                    originalText: cacheKey,
+                    translatedText: translated,
+                    targetLanguage: self.targetLanguage,
+                    timestamp: Date()
+                )
+            } catch {
+                // On error keep showing previous result; don't clear screen.
+            }
+
+            self.isTranslating = false
+        }
+    }
+
+    // MARK: - Language Switching
+
+    func changeLanguage(to language: SupportedLanguage) {
+        guard language != targetLanguage else { return }
+        targetLanguage = language
+
+        // Clear state so the view picks up the new .configuration and
+        // .translationTask fires a fresh session.
+        pendingTask?.cancel()
+        session = nil
+        cache.removeAll()
+        lastInputKey = ""
+        result = nil
+    }
+}

--- a/KoreanTranslationCamera/KoreanTranslationCamera/Views/ControlBarView.swift
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/Views/ControlBarView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+// MARK: - Control Bar
+//
+// A single Pause / Resume button centred at the bottom of the screen.
+
+struct ControlBarView: View {
+
+    let isRunning: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            Label(
+                isRunning ? "Pause" : "Resume",
+                systemImage: isRunning ? "pause.circle.fill" : "play.circle.fill"
+            )
+            .font(.system(size: 18, weight: .semibold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 28)
+            .padding(.vertical, 14)
+            .background(.ultraThinMaterial, in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .animation(.easeInOut(duration: 0.2), value: isRunning)
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        ControlBarView(isRunning: true) {}
+    }
+}

--- a/KoreanTranslationCamera/KoreanTranslationCamera/Views/LanguageSelectorView.swift
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/Views/LanguageSelectorView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+// MARK: - Language Selector
+//
+// Horizontal row of language pills shown at the top of the screen.
+// The active language is highlighted; tapping another pill switches immediately.
+
+struct LanguageSelectorView: View {
+
+    let selectedLanguage: SupportedLanguage
+    let onSelect: (SupportedLanguage) -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            ForEach(SupportedLanguage.allCases) { language in
+                LanguagePill(
+                    language: language,
+                    isSelected: language == selectedLanguage
+                ) {
+                    onSelect(language)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.ultraThinMaterial, in: Capsule())
+    }
+}
+
+// MARK: - Language Pill
+
+private struct LanguagePill: View {
+
+    let language: SupportedLanguage
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(language.displayName)
+                .font(.system(size: 14, weight: isSelected ? .semibold : .regular))
+                .foregroundStyle(isSelected ? Color.black : Color.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(
+                    isSelected ? Color.white : Color.white.opacity(0.15),
+                    in: Capsule()
+                )
+        }
+        .buttonStyle(.plain)
+        .animation(.easeInOut(duration: 0.15), value: isSelected)
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        LanguageSelectorView(selectedLanguage: .english) { _ in }
+    }
+}

--- a/KoreanTranslationCamera/KoreanTranslationCamera/Views/PermissionView.swift
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/Views/PermissionView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+// MARK: - Permission Denied View
+//
+// Shown in place of the camera feed when camera access is not granted.
+// Guides the user to open Settings.
+
+struct PermissionView: View {
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "camera.fill")
+                .font(.system(size: 52))
+                .foregroundStyle(.white.opacity(0.7))
+
+            Text("Camera Access Required")
+                .font(.title2.bold())
+                .foregroundStyle(.white)
+
+            Text("This app needs camera access to detect Korean text. Please enable it in Settings.")
+                .font(.body)
+                .foregroundStyle(.white.opacity(0.8))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
+            Button("Open Settings") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.white)
+            .foregroundStyle(.black)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black)
+    }
+}
+
+#Preview {
+    PermissionView()
+}

--- a/KoreanTranslationCamera/KoreanTranslationCamera/Views/TranslationResultView.swift
+++ b/KoreanTranslationCamera/KoreanTranslationCamera/Views/TranslationResultView.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+// MARK: - Translation Result View
+//
+// Shows the detected Korean text and its translation in a frosted-glass card
+// anchored to the bottom of the screen. Hidden when there's no result yet.
+
+struct TranslationResultView: View {
+
+    let result: TranslationResult?
+    let isTranslating: Bool
+
+    var body: some View {
+        Group {
+            if let result {
+                resultCard(result)
+            } else if isTranslating {
+                loadingCard
+            } else {
+                hintCard
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: result)
+        .animation(.easeInOut(duration: 0.25), value: isTranslating)
+    }
+
+    // MARK: - Sub-views
+
+    private func resultCard(_ result: TranslationResult) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // Original Korean
+            VStack(alignment: .leading, spacing: 4) {
+                Label("Korean", systemImage: "text.magnifyingglass")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+
+                Text(result.originalText)
+                    .font(.system(size: 15, weight: .regular))
+                    .foregroundStyle(.primary)
+                    .lineLimit(4)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Divider()
+
+            // Translation
+            VStack(alignment: .leading, spacing: 4) {
+                Label(result.targetLanguage.displayName, systemImage: "globe")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+
+                Text(result.translatedText)
+                    .font(.system(size: 17, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .lineLimit(6)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    private var loadingCard: some View {
+        HStack(spacing: 10) {
+            ProgressView()
+                .tint(.white)
+            Text("Translating…")
+                .font(.subheadline)
+                .foregroundStyle(.white)
+        }
+        .padding(14)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var hintCard: some View {
+        Text("Point the camera at Korean text")
+            .font(.subheadline)
+            .foregroundStyle(.white.opacity(0.8))
+            .padding(14)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.gray.ignoresSafeArea()
+        VStack {
+            Spacer()
+            TranslationResultView(
+                result: TranslationResult(
+                    originalText: "삼겹살\n된장찌개",
+                    translatedText: "Grilled Pork Belly\nDoenjang Stew",
+                    targetLanguage: .english,
+                    timestamp: Date()
+                ),
+                isTranslating: false
+            )
+            .padding()
+        }
+    }
+}

--- a/KoreanTranslationCamera/README.md
+++ b/KoreanTranslationCamera/README.md
@@ -1,0 +1,102 @@
+# KoreanTranslationCamera
+
+A personal-use iOS app that detects Korean text through the live camera feed and translates it into English, Japanese, or Simplified Chinese in near real time.
+
+## Requirements
+
+| Requirement | Value |
+|---|---|
+| Platform | iPhone only |
+| iOS deployment target | **17.4+** |
+| Xcode | 15.4+ |
+| Swift | 5.10+ |
+
+> **Why iOS 17.4?** The app uses Apple's built-in `Translation` framework (`import Translation`), which was introduced in iOS 17.4. No API key or internet connection is required — language models are downloaded once from Apple's servers and cached on-device.
+
+---
+
+## Features
+
+- **Live camera preview** — full-screen, portrait-locked
+- **Korean OCR** via Apple Vision (`VNRecognizeTextRequest`)
+- **On-device translation** via Apple Translation framework
+- **Target languages** — English · Japanese · Simplified Chinese
+- **Frame throttling** — processes one frame every ~0.75 s to avoid flicker
+- **Translation cache** — repeated text reuses the last result instantly
+- **Pause / Resume** scanning with a single tap
+- **Permission handling** — shows a Settings deep-link if camera is denied
+
+---
+
+## Architecture
+
+```
+KoreanTranslationCamera/
+├── KoreanTranslationCameraApp.swift   Entry point (@main)
+├── ContentView.swift                  Root view; wires all layers together
+│
+├── Models/
+│   └── AppModels.swift                SupportedLanguage enum, TranslationResult struct
+│
+├── Camera/
+│   ├── CameraManager.swift            AVCaptureSession, permission, frame throttling
+│   └── CameraPreviewView.swift        UIViewRepresentable wrapping AVCaptureVideoPreviewLayer
+│
+├── Services/
+│   ├── OCRService.swift               Vision text recognition (Korean filter)
+│   └── TranslationService.swift       Apple Translation session + cache
+│
+└── Views/
+    ├── LanguageSelectorView.swift     Horizontal language pill row (top)
+    ├── TranslationResultView.swift    Frosted-glass result card (bottom)
+    ├── ControlBarView.swift           Pause / Resume button
+    └── PermissionView.swift           Camera permission denied screen
+```
+
+### Data flow
+
+```
+CameraManager
+    │  CVPixelBuffer (every 0.75 s)
+    ▼
+OCRService                   Vision VNRecognizeTextRequest
+    │  [String] Korean text
+    ▼
+TranslationService           Apple Translation session
+    │  TranslationResult
+    ▼
+ContentView / TranslationResultView
+```
+
+---
+
+## Setup in Xcode
+
+1. Clone or download this repository.
+2. Open `KoreanTranslationCamera.xcodeproj` in **Xcode 15.4+**.
+3. Select your **development team** in *Signing & Capabilities* (required to run on a real device).
+4. Change the bundle identifier if needed (`com.personal.KoreanTranslationCamera`).
+5. Connect a physical iPhone running **iOS 17.4+** (camera doesn't work in Simulator).
+6. Build & Run (`⌘R`).
+
+> **Note:** The first time you select each target language, iOS may download the language model in the background (~100–200 MB per language pair). A network connection is needed for this one-time download.
+
+---
+
+## Usage
+
+1. Grant camera permission when prompted.
+2. Select a target language from the pills at the top.
+3. Point the camera at Korean text (restaurant signs, menus, etc.).
+4. The translation appears in the frosted card at the bottom within ~1 second.
+5. Tap **Pause** to freeze scanning; tap **Resume** to continue.
+
+---
+
+## Limitations (MVP)
+
+- Printed text only — no handwriting support
+- Portrait orientation only
+- No history or save feature
+- No offline mode (initial language model download requires internet)
+- No document scanning or freeze-frame inspection


### PR DESCRIPTION
Implements the full PRD: live camera feed via AVFoundation, Korean OCR
via Apple Vision (VNRecognizeTextRequest), and on-device translation into
English / Japanese / Simplified Chinese via Apple's Translation framework
(iOS 17.4+). UI is SwiftUI-only with a frosted-glass result card, language
selector pills, and a pause/resume control.

Architecture: CameraManager → OCRService → TranslationService, each layer
independent and wired together in ContentView. Frame throttling at 0.75 s
and a translation cache prevent redundant work on repeated frames.

https://claude.ai/code/session_01LLiEW7mPeoD4dA6STmsV3x